### PR TITLE
Add shards executable to shims path

### DIFF
--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# let asdf create shims for installed scripts
+echo bin embedded/bin


### PR DESCRIPTION
Right now when you install crystal using asdf you can't access `shards` command just because it only adds executables in `your_installed_crystal_version/bin` and `shards` command is placed in `your_installed_crystal_version/embedded/bin`

Just as ASDF documentation for creating plugins says (https://github.com/asdf-vm/asdf/blob/master/docs/creating-plugins.md) I have added a new file `bin/list-bin-paths` where I specify both `bin` and `embedded/bin` as directories that hold executables to be linked when running `asdf reshim crystal`