### PR TITLE
use grep without perl option, escape dots in version

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -66,7 +66,7 @@ get_download_url() {
     [ "Linux" = "$(uname)" ] && operating_system="linux" || operating_system="darwin"
     [ "x86_64" = "$(uname -m)" ] && arch="x86_64" || arch="i686"
 
-    local grep_cmd="grep -oP ((https).*(crystal-${version}).*(${operating_system}).*(${arch}).*tar.gz)"
+    local grep_cmd="grep -o https.*crystal-${version//\./\\.}.*${operating_system}.*${arch}.*tar.gz"
     local curl_cmd="curl -s https://api.github.com/repos/crystal-lang/crystal/releases"
 
     if [ "$install_type" = "version" ]; then


### PR DESCRIPTION
This fixes #4 so it works on the macOS version of grep, which doesn't have the -P flag. It also escapes the dots in the version string before passing to grep.